### PR TITLE
Use a liveall gauge to represent circuit state

### DIFF
--- a/circuitbreaker/stats.py
+++ b/circuitbreaker/stats.py
@@ -22,7 +22,7 @@ place. The states can be one of the following values:
 
 """
 
-circuit_breaker_state = Gauge("circuit_breaker_state", "State of Circuit Breaker", ["name"])
+circuit_breaker_state = Gauge("circuit_breaker_state", "State of Circuit Breaker", ["name"], multiprocess_mode='liveall')
 circuit_breaker_failure_total = Counter("circuit_breaker_failure_total", "Count of failed remote calls", ["name", "state"])
 circuit_breaker_success_total = Counter("circuit_breaker_success_total", "Count of success remote calls", ["name", "state"])
 


### PR DESCRIPTION
By default, the prometheus client library, when declaring a gauge in multiprocess mode, will track a timeseries for each process. This doesn't make sense for gunicorn, which constantly forks new processes; we don't care about the state of a circuitbreaker for a pid that stopped serving requests ours ago. This causes a bunch of bloat, as we allocate a 1MB file for every process to track those gauges, resulting in gigabytes allocated.

This change uses liveall, which will create a timeseries for every gunicorn worker that is currently running (which can be over 100 in some pods), but does not track those from dead processes